### PR TITLE
WITI-432 - CustomFields not required on registration

### DIFF
--- a/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
+++ b/react/admin/OrganizationDetails/OrganizationDetailsCostCenters.tsx
@@ -351,13 +351,7 @@ const OrganizationDetailsCostCenters = ({
                   !newCostCenterName ||
                   !isValidAddress(newCostCenterAddressState) ||
                   (newCostCenterPhoneNumber &&
-                    !validatePhoneNumber(newCostCenterPhoneNumber)) ||
-                  // custom fields need to be filled
-                  costCenterCustomFieldsState?.some(
-                    (customField: CustomField) => {
-                      return !customField.value
-                    }
-                  )
+                    !validatePhoneNumber(newCostCenterPhoneNumber))
                 }
               >
                 {formatMessage(messages.add)}

--- a/react/admin/OrganizationsList.tsx
+++ b/react/admin/OrganizationsList.tsx
@@ -570,16 +570,7 @@ const OrganizationsList: FunctionComponent = () => {
                   !newCostCenterName ||
                   !isValidAddress(newCostCenterAddressState) ||
                   (newCostCenterPhoneNumber &&
-                    !validatePhoneNumber(newCostCenterPhoneNumber)) ||
-                  // custom fields need to be filled
-                  orgCustomFieldsState?.some((customField: CustomField) => {
-                    return !customField.value
-                  }) ||
-                  costCenterCustomFieldsState?.some(
-                    (customField: CustomField) => {
-                      return !customField.value
-                    }
-                  )
+                    !validatePhoneNumber(newCostCenterPhoneNumber))
                 }
               >
                 {formatMessage(messages.add)}

--- a/react/components/NewCostCenterModal.tsx
+++ b/react/components/NewCostCenterModal.tsx
@@ -149,13 +149,7 @@ const NewCostCenterModal: FunctionComponent<Props> = ({
                 !newCostCenterName ||
                 !isValidAddress(newCostCenterAddressState) ||
                 (newCostCenterPhoneNumber &&
-                  !validatePhoneNumber(newCostCenterPhoneNumber)) ||
-                // custom fields need to be filled
-                costCenterCustomFieldsState?.some(
-                  (customField: CustomField) => {
-                    return !customField.value
-                  }
-                )
+                  !validatePhoneNumber(newCostCenterPhoneNumber))
               }
             >
               {formatMessage(messages.add)}

--- a/react/components/RequestOrganizationForm.tsx
+++ b/react/components/RequestOrganizationForm.tsx
@@ -633,16 +633,7 @@ const RequestOrganizationForm: FC = () => {
                     !validateEmail(formState.email) ||
                     !isValidAddress(addressState) ||
                     (formState.phoneNumber &&
-                      !validatePhoneNumber(formState.phoneNumber)) ||
-                    // custom fields need to be filled
-                    orgCustomFieldsState?.some((customField: CustomField) => {
-                      return !customField.value
-                    }) ||
-                    costCenterCustomFieldsState?.some(
-                      (customField: CustomField) => {
-                        return !customField.value
-                      }
-                    )
+                      !validatePhoneNumber(formState.phoneNumber))
                   }
                 >
                   <FormattedMessage id="store/b2b-organizations.request-new-organization.submit-button.label" />


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Removed requirement for custom fields to be filled on when registering org/cost center

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

https://witi432--whitebird.myvtex.com/account#/organization


