### PR TITLE
WITI-450 - Removed button to add cost centers

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,9 @@
   },
   "billingOptions": {
     "type": "free",
-    "availableCountries": ["*"]
+    "availableCountries": [
+      "*"
+    ]
   },
   "dependencies": {
     "vtex.b2b-organizations-graphql": "0.x",

--- a/react/components/OrganizationDetails.tsx
+++ b/react/components/OrganizationDetails.tsx
@@ -340,15 +340,6 @@ const OrganizationDetails: FunctionComponent<RouterProps> = ({
                   ?.pagination?.total ?? 0,
               rowsOptions: [25, 50, 100],
             }}
-            toolbar={{
-              newLine: {
-                label: formatMessage(messages.new),
-                handleCallback: () => setNewCostCenterModalState(true),
-                disabled: !permissionsState.includes(
-                  'create-cost-center-organization'
-                ),
-              },
-            }}
           />
         </PageBlock>
       )}


### PR DESCRIPTION
#### What problem is this solving?

Whitebird wanted to restrict the ability to add a new cost center

#### How to test it?
[WITI-450 - Go here and login](https://witi450--whitebird.myvtex.com/account#/organization)
